### PR TITLE
Do not rely on current datetime for developer stats

### DIFF
--- a/src/Controller/ReviewStatsHomeController.php
+++ b/src/Controller/ReviewStatsHomeController.php
@@ -79,7 +79,11 @@ class ReviewStatsHomeController extends AbstractController
             throw $this->createNotFoundException('No developer');
         }
 
-        $developerStats = $this->statisticsService->getDeveloperStats($login);
+        $developerStats = $this->statisticsService->getDeveloperStats(
+            $login,
+            90,
+            new DateTime()
+        );
 
         return $this->render('developer_stats.html.twig',
             ['stats' => $developerStats, 'login' => $login]

--- a/src/Helper/ReviewStatsService.php
+++ b/src/Helper/ReviewStatsService.php
@@ -116,17 +116,18 @@ ORDER BY day DESC',
 
     /**
      * @param string $login
+     * @param int $howManyDays
+     * @param DateTime $endDate
      *
      * @return array<int, array<string, mixed>>
      */
-    public function getDeveloperStats(string $login): array
+    public function getDeveloperStats(string $login, int $howManyDays, DateTime $endDate): array
     {
-        $today = new DateTime();
-        $threeMonthBefore = DayComputer::getXDayBefore(90, $today);
+        $beginDate = DayComputer::getXDayBefore($howManyDays, $endDate);
 
         $sql = sprintf(
             'SELECT day, PR, total FROM reviews WHERE login = \'%s\' AND day BETWEEN \'%s\' AND \'%s\'
-ORDER BY day DESC', $login, $threeMonthBefore->format('Y-m-d'), $today->format('Y-m-d'));
+ORDER BY day DESC', $login, $beginDate->format('Y-m-d'), $endDate->format('Y-m-d'));
 
         $result = $this->pdo->query($sql)->fetchAll();
 

--- a/tests/Helper/ReviewStatsServiceTest.php
+++ b/tests/Helper/ReviewStatsServiceTest.php
@@ -38,7 +38,11 @@ class ReviewStatsServiceTest extends KernelTestCase
 
         $statsService = new ReviewStatsService($this->getPDO());
 
-        $stats = $statsService->getDeveloperStats('matks');
+        $stats = $statsService->getDeveloperStats(
+            'matks',
+            10,
+            new DateTime('2021-12-06')
+        );
 
         $this->assertEquals($stats[0]['day'], '2021-12-05');
         $this->assertEquals($stats[0]['total'], 2);
@@ -52,7 +56,11 @@ class ReviewStatsServiceTest extends KernelTestCase
 
         $statsService = new ReviewStatsService($this->getPDO());
 
-        $stats = $statsService->getDeveloperStats('PierreRambaud');
+        $stats = $statsService->getDeveloperStats(
+            'PierreRambaud',
+            10,
+            new DateTime('2021-12-06')
+        );
 
         $this->assertEquals($stats[0]['day'], '2021-12-02');
         $this->assertEquals($stats[0]['total'], 20);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Do not rely on current datetime for developer stats
| Type?             | bug fix
| Fixed ticket?     | Fixes https://github.com/PrestaShop/ps-project-metrics/issues/25