### PR TITLE
Fix weekend display

### DIFF
--- a/src/Helper/TeamHelper.php
+++ b/src/Helper/TeamHelper.php
@@ -52,7 +52,7 @@ class TeamHelper
     {
         $team = [
             'PierreRambaud' => ['full-time' => true],      # Pierre R.
-            'matks' => ['full-time' => true],              # Mathieu F.
+            'matks' => ['full-time' => false],             # Mathieu F.
             'jolelievre' => ['full-time' => true],         # Jonathan L.
             'matthieu-rolland' => ['full-time' => true],   # Matthieu R.
             'Progi1984' => ['full-time' => true],          # Franck L.

--- a/templates/review_stats.html.twig
+++ b/templates/review_stats.html.twig
@@ -23,6 +23,14 @@
       {% endif %}
     {% elseif (displayBadge == false ) %}
       <span>{{ total }}</span>
+    {% elseif (total == 0 ) and (key in weekendDays ) %}
+        {% set label = '(w-e)' %}
+        {% set badge = 'bg-info' %}
+        {% if (displayBadge == true ) %}
+          {{ _self.displayInBadge(label, badge) }}
+        {% else %}
+          <span>{{ label }}</span>
+        {% endif %}
     {% elseif (total <= 2 ) %}
       {{ _self.displayInBadge(total, 'bg-danger') }}
     {% elseif (total <= 4 ) %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix weekend display. If number of reviews in weekend is zero display `(week-end)`
| Type?             | bug fix

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
